### PR TITLE
The FreeTypeFont object from the PIL library no longer has the getsize() method

### DIFF
--- a/img2img.py
+++ b/img2img.py
@@ -41,7 +41,10 @@ def main(opt):
         cell_height = 12
         num_cols = int(width / cell_width)
         num_rows = int(height / cell_height)
-    char_width, char_height = font.getsize(sample_character)
+    bbox = font.getbbox(sample_character)
+    char_width = bbox[2] - bbox[0]
+    char_height = bbox[3] - bbox[1]
+    
     out_width = char_width * num_cols
     out_height = scale * char_height * num_rows
     out_image = Image.new("L", (out_width, out_height), bg_code)

--- a/img2img_color.py
+++ b/img2img_color.py
@@ -43,7 +43,10 @@ def main(opt):
         cell_height = 12
         num_cols = int(width / cell_width)
         num_rows = int(height / cell_height)
-    char_width, char_height = font.getsize(sample_character)
+    bbox = font.getbbox(sample_character)
+    char_width = bbox[2] - bbox[0]
+    char_height = bbox[3] - bbox[1]
+    
     out_width = char_width * num_cols
     out_height = scale * char_height * num_rows
     out_image = Image.new("RGB", (out_width, out_height), bg_code)

--- a/utils.py
+++ b/utils.py
@@ -4,15 +4,18 @@ from PIL import Image, ImageFont, ImageDraw, ImageOps
 
 def sort_chars(char_list, font, language):
     if language == "chinese":
-        char_width, char_height = font.getsize("制")
+        bbox  = font.getbbox("制")
     elif language == "korean":
-        char_width, char_height = font.getsize("ㅊ")
+        bbox  = font.getbbox("ㅊ")
     elif language == "japanese":
-        char_width, char_height = font.getsize("あ")
+        bbox  = font.getbbox("あ")
     elif language in ["english", "german", "french", "spanish", "italian", "portuguese", "polish"]:
-        char_width, char_height = font.getsize("A")
+        bbox  = font.getbbox("A")
     elif language == "russian":
-        char_width, char_height = font.getsize("A")
+        bbox  = font.getbbox("A")
+    char_width = bbox[2] - bbox[0]
+    char_height = bbox[3] - bbox[1]
+
     num_chars = min(len(char_list), 100)
     out_width = char_width * len(char_list)
     out_height = char_height

--- a/video2video.py
+++ b/video2video.py
@@ -57,7 +57,10 @@ def main(opt):
             cell_height = 12
             num_cols = int(width / cell_width)
             num_rows = int(height / cell_height)
-        char_width, char_height = font.getsize("A")
+        bbox = font.getbbox("A")
+        char_width = bbox[2] - bbox[0]
+        char_height = bbox[3] - bbox[1]
+
         out_width = char_width * num_cols
         out_height = 2 * char_height * num_rows
         out_image = Image.new("L", (out_width, out_height), bg_code)

--- a/video2video_color.py
+++ b/video2video_color.py
@@ -57,7 +57,10 @@ def main(opt):
             cell_height = 12
             num_cols = int(width / cell_width)
             num_rows = int(height / cell_height)
-        char_width, char_height = font.getsize("A")
+        bbox = font.getbbox("A")
+        char_width = bbox[2] - bbox[0]
+        char_height = bbox[3] - bbox[1]
+
         out_width = char_width * num_cols
         out_height = 2 * char_height * num_rows
         out_image = Image.new("RGB", (out_width, out_height), bg_code)


### PR DESCRIPTION
The FreeTypeFont object from the PIL library no longer has the getsize() method, use the getbbox() method instead.