### PR TITLE
Create PIL_version_error.md

### DIFF
--- a/PIL_version_error.md
+++ b/PIL_version_error.md
@@ -1,0 +1,23 @@
+The error occurs because the `getsize` method is no longer available in newer versions of the Pillow (PIL) library for `FreeTypeFont` objects. This method has been deprecated and removed. Specifically, the error message is:
+
+```
+AttributeError: 'FreeTypeFont' object has no attribute 'getsize'
+```
+
+This indicates that the `font.getsize()` call is not recognized as a valid method for `FreeTypeFont`. 
+
+To resolve the issue, you should replace the `getsize` method with `font.getbbox()` or `font.getmask()` in your code. The `getbbox()` method returns the bounding box (the coordinates of the character's box), which can then be used to calculate the width and height of the character. For example, replace:
+
+```python
+char_width, char_height = font.getsize("A")
+```
+
+With:
+
+```python
+bbox = font.getbbox("A")
+char_width = bbox[2] - bbox[0]
+char_height = bbox[3] - bbox[1]
+```
+
+This change will allow the code to run properly on newer versions of Pillow.

--- a/img2img.py
+++ b/img2img.py
@@ -41,7 +41,11 @@ def main(opt):
         cell_height = 12
         num_cols = int(width / cell_width)
         num_rows = int(height / cell_height)
-    char_width, char_height = font.getsize(sample_character)
+    # char_width, char_height = font.getsize(sample_character)
+    bbox = font.getbbox("A")
+    char_width = bbox[2] - bbox[0]
+    char_height = bbox[3] - bbox[1]
+
     out_width = char_width * num_cols
     out_height = scale * char_height * num_rows
     out_image = Image.new("L", (out_width, out_height), bg_code)

--- a/img2img_color.py
+++ b/img2img_color.py
@@ -43,7 +43,11 @@ def main(opt):
         cell_height = 12
         num_cols = int(width / cell_width)
         num_rows = int(height / cell_height)
-    char_width, char_height = font.getsize(sample_character)
+    # char_width, char_height = font.getsize(sample_character)
+    bbox = font.getbbox("A")
+    char_width = bbox[2] - bbox[0]
+    char_height = bbox[3] - bbox[1]
+
     out_width = char_width * num_cols
     out_height = scale * char_height * num_rows
     out_image = Image.new("RGB", (out_width, out_height), bg_code)

--- a/utils.py
+++ b/utils.py
@@ -10,9 +10,16 @@ def sort_chars(char_list, font, language):
     elif language == "japanese":
         char_width, char_height = font.getsize("あ")
     elif language in ["english", "german", "french", "spanish", "italian", "portuguese", "polish"]:
-        char_width, char_height = font.getsize("A")
+        # char_width, char_height = font.getsize("A")
+        bbox = font.getbbox("A")
+        char_width = bbox[2] - bbox[0]
+        char_height = bbox[3] - bbox[1]
     elif language == "russian":
         char_width, char_height = font.getsize("A")
+        # bbox = font.getbbox("A")
+        # char_width = bbox[2] - bbox[0]
+        # char_height = bbox[3] - bbox[1]
+
     num_chars = min(len(char_list), 100)
     out_width = char_width * len(char_list)
     out_height = char_height

--- a/video2video.py
+++ b/video2video.py
@@ -57,7 +57,11 @@ def main(opt):
             cell_height = 12
             num_cols = int(width / cell_width)
             num_rows = int(height / cell_height)
-        char_width, char_height = font.getsize("A")
+        # char_width, char_height = font.getsize("A")
+        bbox = font.getbbox("A")
+        char_width = bbox[2] - bbox[0]
+        char_height = bbox[3] - bbox[1]
+
         out_width = char_width * num_cols
         out_height = 2 * char_height * num_rows
         out_image = Image.new("L", (out_width, out_height), bg_code)

--- a/video2video_color.py
+++ b/video2video_color.py
@@ -57,7 +57,11 @@ def main(opt):
             cell_height = 12
             num_cols = int(width / cell_width)
             num_rows = int(height / cell_height)
-        char_width, char_height = font.getsize("A")
+        # char_width, char_height = font.getsize("A")
+        bbox = font.getbbox("A")
+        char_width = bbox[2] - bbox[0]
+        char_height = bbox[3] - bbox[1]
+
         out_width = char_width * num_cols
         out_height = 2 * char_height * num_rows
         out_image = Image.new("RGB", (out_width, out_height), bg_code)


### PR DESCRIPTION
The error occurs because the getsize method is no longer available in newer versions of the Pillow (PIL) library for FreeTypeFont objects. This method has been deprecated and removed.